### PR TITLE
Feat/users whitelist

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           cd ./${{ env.CI_JOB_ID }}
           touch .env
-          echo JOIN_ON_INVITE=${{ vars.JOIN_ON_INVITE }} >> .env
           echo SALT=${{ secrets.SALT }} >> .env
           echo MATRIX_HOME_SERVER=${{ secrets.MATRIX_HOME_SERVER }} >> .env
           echo MATRIX_BOT_USERNAME=${{ secrets.MATRIX_BOT_USERNAME }} >> .env

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@
 # Project-specific
 store
 session.txt
-users_pending.txt
-users_whitelist.txt
+users.json
 
 *.pyc
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Project-specific
 store
 session.txt
+users_pending.txt
+users_whitelist.txt
 
 *.pyc
 __pycache__

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ cp app/.env.example app/.env
 
 Les variables d'environnement à renseigner sont les suivantes :
 
-- `JOIN_ON_INVITE` : booléen facultatif pour activer ou non l'acceptation automatique des invitations dans les salons (exemple : `JOIN_ON_INVITE=True`. Par défaut, `False`)
 - `SALT` : il est conseillé de changer la valeur du salt pour ne pas avoir celle par défaut. Il faudra en revanche qu'elle de change pas entre deux sessions.
 - `MATRIX_HOME_SERVER` : l'URL du serveur Matrix à utiliser (exemple : `MATRIX_HOME_SERVER="https://matrix.agent.ministere_example.tchap.gouv.fr"`)
 - `MATRIX_BOT_USERNAME` : le nom d'utilisateur du bot Matrix (exemple : `MATRIX_BOT_USERNAME="tchapbot@ministere_example.gouv.fr"`)
@@ -167,7 +166,6 @@ cp app/.env.example app/.env
 
 The following environment variables must be entered:
 
-- `JOIN_ON_INVITE`: optional boolean to enable or disable automatic acceptance of invitations to Tchap rooms (example: `JOIN_ON_INVITE=True`. Default: `False`).
 - `SALT`: it is advisable to change the salt value to avoid having the default one. However, it must not change between sessions.
 - `MATRIX_HOME_SERVER`: the URL of the Matrix server to be used (example: `MATRIX_HOME_SERVER=“https://matrix.agent.ministere_example.tchap.gouv.fr”`).
 - `MATRIX_BOT_USERNAME`: the Matrix bot username (example: `MATRIX_BOT_USERNAME=“tchapbot@ministere_example.gouv.fr”`)

--- a/app/.env.example
+++ b/app/.env.example
@@ -5,7 +5,6 @@
 
 VERBOSE=False
 SYSTEMD_LOGGING=True
-JOIN_ON_INVITE=True
 SALT=b"\xce,\xa1\xc6lY\x80\xe3X}\x91\xa60m\xa8N"
 MATRIX_HOME_SERVER="https://matrix.agent.ministere_example.tchap.gouv.fr"
 MATRIX_BOT_USERNAME="jean.quidam@ministere_example.gouv.fr"

--- a/app/commands.py
+++ b/app/commands.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import time
 from collections import defaultdict
 from dataclasses import dataclass
 
@@ -150,25 +149,7 @@ def register_feature(
 )
 async def help(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
-    await matrix_client.room_typing(ep.room.room_id)
-    await matrix_client.send_markdown_message(ep.room.room_id, command_registry.get_help(config))
-
-
-@register_feature(
-    group="albert",
-    onEvent=RoomMemberEvent,
-    # @DEBUG: RoomCreateEvent is not captured ?
-    help=None,
-)
-async def albert_welcome(ep: EventParser, matrix_client: MatrixClient):
-    """
-    Receive the join/invite event and send the welcome/help message
-    """
-    config = user_configs[ep.sender]
-    ep.only_on_direct_message()
-    ep.only_on_join()
-    config.update_last_activity()
-    time.sleep(3)  # wait for the room to be ready - otherwise the encryption seems to be not ready
+    await ep.only_allowed_sender(config)
     await matrix_client.room_typing(ep.room.room_id)
     await matrix_client.send_markdown_message(ep.room.room_id, command_registry.get_help(config))
 
@@ -181,6 +162,7 @@ async def albert_welcome(ep: EventParser, matrix_client: MatrixClient):
 )
 async def albert_reset(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
+    await ep.only_allowed_sender(config)
     if config.albert_with_history:
         config.update_last_activity()
         await matrix_client.room_typing(ep.room.room_id)
@@ -201,6 +183,7 @@ async def albert_reset(ep: EventParser, matrix_client: MatrixClient):
 )
 async def albert_conversation(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
+    await ep.only_allowed_sender(config)
     await matrix_client.room_typing(ep.room.room_id)
     if config.albert_with_history:
         config.albert_with_history = False
@@ -222,6 +205,7 @@ async def albert_conversation(ep: EventParser, matrix_client: MatrixClient):
 )
 async def albert_debug(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
+    await ep.only_allowed_sender(config)
     await matrix_client.room_typing(ep.room.room_id)
     debug_message = f"Configuration actuelle :\n\n"
     debug_message += f"- Version: {APP_VERSION}\n"
@@ -271,6 +255,7 @@ async def albert_model(ep: EventParser, matrix_client: MatrixClient):
 )
 async def albert_mode(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
+    await ep.only_allowed_sender(config)
     await matrix_client.room_typing(ep.room.room_id)
     commands = ep.event.body.split()
     # Get all available mode for the current model
@@ -297,8 +282,8 @@ async def albert_mode(ep: EventParser, matrix_client: MatrixClient):
 )
 async def albert_sources(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
+    await ep.only_allowed_sender(config)
     await matrix_client.room_typing(ep.room.room_id)
-
     try:
         if config.albert_stream_id:
             sources = generate_sources(config=config, stream_id=config.albert_stream_id)
@@ -328,8 +313,17 @@ async def albert_answer(ep: EventParser, matrix_client: MatrixClient):
     """
     Receive a message event which is not a command, send the prompt to Albert API and return the response to the user
     """
-    # user_prompt: str = await ep.hl()
     config = user_configs[ep.sender]
+    await ep.only_allowed_sender(config)
+
+    # If the user has never used Albert, we send the help message
+    if not config.has_activity(ep.sender):
+        config.update_last_activity(ep.sender)
+        await matrix_client.room_typing(ep.room.room_id)
+        await matrix_client.send_markdown_message(
+            ep.room.room_id, command_registry.get_help(config)
+        )
+
     user_prompt = ep.event.body
     if user_prompt.startswith(COMMAND_PREFIX):
         raise EventNotConcerned
@@ -347,7 +341,7 @@ async def albert_answer(ep: EventParser, matrix_client: MatrixClient):
             ep.room.room_id, reset_message, msgtype="m.notice"
         )
 
-    config.update_last_activity()
+    config.update_last_activity(ep.sender)
     await matrix_client.room_typing(ep.room.room_id, typing_state=True, timeout=180_000)
     try:
         answer = generate(config=config, query=query)

--- a/app/commands.py
+++ b/app/commands.py
@@ -323,6 +323,12 @@ async def albert_answer(ep: EventParser, matrix_client: MatrixClient):
         await matrix_client.send_markdown_message(
             ep.room.room_id, command_registry.get_help(config)
         )
+        # Redirect the error message to the errors room if it exists
+        if config.errors_room_id:
+            await matrix_client.send_markdown_message(
+                config.errors_room_id,
+                f"\u26a0\ufe0f **New Albert Tchap user access request**\n\n{ep.sender}\n\nMatrix server: {config.matrix_home_server}",
+            )
 
     user_prompt = ep.event.body
     if user_prompt.startswith(COMMAND_PREFIX):

--- a/app/commands.py
+++ b/app/commands.py
@@ -164,7 +164,7 @@ async def albert_reset(ep: EventParser, matrix_client: MatrixClient):
     config = user_configs[ep.sender]
     await ep.only_allowed_sender(config)
     if config.albert_with_history:
-        config.update_last_activity()
+        config.update_last_activity(ep.sender)
         await matrix_client.room_typing(ep.room.room_id)
         config.albert_chat_id = new_chat(config)
         reset_message = "**La conversation a été remise à zéro.**\n\n"
@@ -190,7 +190,7 @@ async def albert_conversation(ep: EventParser, matrix_client: MatrixClient):
         config.albert_chat_id = None
         message = "Le mode conversation est désactivé."
     else:
-        config.update_last_activity()
+        config.update_last_activity(ep.sender)
         config.albert_with_history = True
         message = "Le mode conversation est activé."
     await matrix_client.send_text_message(ep.room.room_id, message)

--- a/app/matrix_bot/callbacks.py
+++ b/app/matrix_bot/callbacks.py
@@ -15,7 +15,7 @@ from nio import (
 )
 
 from .client import MatrixClient
-from .config import bot_lib_config, logger
+from .config import logger
 from .eventparser import (
     EventNotConcerned,
     EventParser,
@@ -82,7 +82,6 @@ class Callbacks:
                 )
 
             ep.do_not_accept_own_message()  # avoid infinite loop
-            await ep.only_allowed_sender()  # only allowed senders
             await func(ep=ep, matrix_client=self.matrix_client)
 
         self.client_callback.append((wrapped_func, onEvent))
@@ -101,8 +100,7 @@ class Callbacks:
 
     async def setup_callbacks(self):
         """Add callbacks to async_client"""
-        if bot_lib_config.join_on_invite:
-            self.matrix_client.add_event_callback(self.invite_callback, InviteMemberEvent)
+        self.matrix_client.add_event_callback(self.invite_callback, InviteMemberEvent)
 
         self.matrix_client.add_event_callback(self.decryption_failure, MegolmEvent)
 

--- a/app/matrix_bot/config.py
+++ b/app/matrix_bot/config.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Pôle d'Expertise de la Régulation Numérique <contact.peren@finances.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
+import json
 import logging
 from pathlib import Path
 
@@ -21,9 +22,6 @@ class BotLibConfig(BaseSettings):
         description="The maximum time that the server should wait for new events before "
         "it should return the request anyways, in milliseconds",
     )
-    join_on_invite: bool = Field(
-        default=False, description="Do the bot automatically join when invited"
-    )
     encryption_enabled: bool = Field(default=ENCRYPTION_ENABLED)
     ignore_unverified_devices: bool = Field(default=True, description="True by default in Element")
     store_path: Path = Field(
@@ -32,6 +30,10 @@ class BotLibConfig(BaseSettings):
     session_path: Path = Field(
         default="/data/session.txt", description="path of the file to store session identifier"
     )
+    users_path: Path = Field(
+        default="/data/users.json", description="path of the file to store pending users"
+    )
+    users: dict = Field(default={}, description="pending users")
     log_level: int = Field(default=logging.INFO, description="log level for the library")
     salt: bytes = Field(
         default=b"\xce,\xa1\xc6lY\x80\xe3X}\x91\xa60m\xa8N",
@@ -42,6 +44,20 @@ class BotLibConfig(BaseSettings):
     )
 
     model_config = SettingsConfigDict(env_file=Path(".matrix_bot_env"))
+
+    def __init__(self):
+        super().__init__()
+        if not self.users_path.exists():
+            with open(self.users_path, "w") as f:
+                json.dump({}, f)
+            self.users = {}
+        else:
+            with open(self.users_path, "r") as f:
+                self.users: dict = json.load(f)
+
+    def save_users(self):
+        with open(self.users_path, "w") as f:
+            json.dump(self.users, f, indent=2)
 
 
 bot_lib_config = BotLibConfig()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - VERBOSE=true
       - SYSTEMD_LOGGING=True
       - SESSION_PATH=/data/session.txt
-      - JOIN_ON_INVITE=${JOIN_ON_INVITE}
       - SALT=${SALT}
       - MATRIX_HOME_SERVER=${MATRIX_HOME_SERVER}
       - MATRIX_BOT_USERNAME=${MATRIX_BOT_USERNAME}


### PR DESCRIPTION
Related issue: https://github.com/etalab-ia/albert-tchapbot/issues/54

For the beta, each user shuld be able to join the private room with Albert, be must be individually approved one by one to access the beta to be able to talk to the bot, and received information message if they are not yet approved.

For that:
1) Removed JOIN_ON_INVITE logic since all users join automatically
2) we need persistent storage (even if the bot has been stopped and restarted / redeployed) to have persistent info about:
- users who have asked for access (by starting a chat session with the bot)
- users who have been approved
- users who never talked with the bot before (so that the bot knows if it should send the welcome message or not sending it again)

In this PR, those three informations for each users are stored in a simple `users.json` file for now, structured like this:
```json
{
	"@user-tchap-id-1": {
		"authorized": false,
		"has_activity": false
	},
	"@user-tchap-id-2": {
		"authorized": true,
		"has_activity": false
	}
}
```
When a user joins and starts talking to the bot, he will be added to that file as a pending user, with "authorized": false and "has_activity": false.

This file is loaded (or created) on the launch of the bot and the data is cached as a Python dict in the field `users` of the `BotLibConfig` instance.

To check if he user is authorized, we use a new `is_authorized` field. If empty, we read from the `users` field..
When updating that field, we also re-save the file for persistent info.

To check if it's the first time the user talks with the bot (so that we can know if we send the welcome message), we use that existing `last_activity` field. If empty, we read from the `users` field.
When updating the last activity, if there were none before, we also update the file.


